### PR TITLE
Fixed bug when media has already been loaded

### DIFF
--- a/acornmediaplayer/jquery.acornmediaplayer.js
+++ b/acornmediaplayer/jquery.acornmediaplayer.js
@@ -889,22 +889,27 @@
 				
 				if(!options.nativeSliders) initSeek();
 				
-				// once the metadata has loaded
-				acorn.$self.bind('loadedmetadata', function() {					
-					/* I use an interval to make sure the video has the right readyState
-					 * to bypass a known webkit bug that causes loadedmetadata to be triggered
-					 * before the duration is available
-					 */
-					var t = window.setInterval(function() {
-								if (acorn.$self[0].readyState > 0) {									
-									updateSeek();
+				// check first to see if the media has already loaded
+				if (acorn.$self[0].readyState > 0) {
+					updateSeek();
+				} else {
+					// once the metadata has loaded
+					acorn.$self.bind('loadedmetadata', function() {
+						/* I use an interval to make sure the video has the right readyState
+						 * to bypass a known webkit bug that causes loadedmetadata to be triggered
+						 * before the duration is available
+						 */
+						var t = window.setInterval(function() {
+									if (acorn.$self[0].readyState > 0) {
+										updateSeek();
 									
-									clearInterval(t);
-								}
-							}, 500);
+										clearInterval(t);
+									}
+								}, 500);
 					
-					initCaption();					
-				});				
+						initCaption();					
+					});
+				}
 								
 				// remove the native controls
 				acorn.$self.removeAttr('controls');


### PR DESCRIPTION
I found a bug in Firefox where if I reloaded the page the media would already be loaded by the time the init() method was called to add a listener for 'loadedmetadata'. This caused the loading circle to never be removed because the updateSeek() method was never called.

I put in a fix to first check to see if the media is loaded and if it is immediately call the updateSeek() method.
